### PR TITLE
회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/noplanb/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/noplanb/domain/auth/repository/TokenRepository.java
@@ -1,6 +1,7 @@
 package com.noplanb.domain.auth.repository;
 
 import com.noplanb.domain.auth.domain.Token;
+import com.noplanb.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,7 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface TokenRepository extends JpaRepository<Token, Long> {
-    Optional<Token> findByEmail(String email);
+    Token findByEmail(String email);
     Optional<Token> findByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/com/noplanb/domain/character/domain/Character.java
+++ b/src/main/java/com/noplanb/domain/character/domain/Character.java
@@ -30,16 +30,15 @@ public class Character extends BaseEntity {
     private Long todayExp;
     private Long level;
 
-//    @OneToOne(mappedBy = "character", fetch = FetchType.LAZY)
-//    private User user;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true)
     private User user;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Quest> quests = new ArrayList<>();
-    @OneToMany(mappedBy = "character")
+
+    @OneToMany(mappedBy = "character", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Item> items = new ArrayList<>();
 
 

--- a/src/main/java/com/noplanb/domain/character/repository/CharacterRepository.java
+++ b/src/main/java/com/noplanb/domain/character/repository/CharacterRepository.java
@@ -12,4 +12,6 @@ public interface CharacterRepository extends JpaRepository<Character,Long> {
     Optional<Character> findByUserId(Long id);
 
     boolean existsByUser(User user);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/noplanb/domain/user/application/UserService.java
+++ b/src/main/java/com/noplanb/domain/user/application/UserService.java
@@ -61,4 +61,18 @@ public class UserService {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @Transactional
+    public ResponseEntity<?> cancelAccount(UserPrincipal userPrincipal) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        characterRepository.deleteByUser(user);
+        userRepository.delete(user);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information("회원 탈퇴가 완료되었습니다.")
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
 }

--- a/src/main/java/com/noplanb/domain/user/application/UserService.java
+++ b/src/main/java/com/noplanb/domain/user/application/UserService.java
@@ -1,5 +1,7 @@
 package com.noplanb.domain.user.application;
 
+import com.noplanb.domain.auth.domain.Token;
+import com.noplanb.domain.auth.repository.TokenRepository;
 import com.noplanb.domain.character.domain.Character;
 import com.noplanb.domain.character.repository.CharacterRepository;
 import com.noplanb.domain.user.domain.User;
@@ -21,7 +23,8 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class UserService {
 
-    final UserRepository userRepository;
+    private final TokenRepository tokenRepository;
+    private final UserRepository userRepository;
     private final CharacterRepository characterRepository;
 
     @Transactional
@@ -64,8 +67,16 @@ public class UserService {
     @Transactional
     public ResponseEntity<?> cancelAccount(UserPrincipal userPrincipal) {
         User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        String email = user.getEmail();
 
+        // 토큰 정보 삭제
+        Token token = tokenRepository.findByEmail(email);
+        if (token != null) { tokenRepository.delete(token); }
+
+        // 캐릭터 정보 삭제
         characterRepository.deleteByUser(user);
+
+        // 유저 정보 삭제
         userRepository.delete(user);
 
         ApiResponse apiResponse = ApiResponse.builder()

--- a/src/main/java/com/noplanb/domain/user/controller/UserController.java
+++ b/src/main/java/com/noplanb/domain/user/controller/UserController.java
@@ -18,7 +18,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -47,5 +49,17 @@ public class UserController {
     @GetMapping("/character-exist")
     public ResponseEntity<?> getUserCharacterExist(@Parameter @CurrentUser UserPrincipal userPrincipal){
         return userService.getUserCharacterExist(userPrincipal);
+    }
+
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
+            @ApiResponse(responseCode = "400", description = "탈퇴 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
+    })
+    @DeleteMapping("/user")
+    public ResponseEntity<?> cancelAccount(@Parameter @CurrentUser UserPrincipal userPrincipal) {
+        {
+            return userService.cancelAccount(userPrincipal);
+        }
     }
 }


### PR DESCRIPTION
## 🌻 Summary
> 어떤 내용의 PR인가요?
- 회원 탈퇴 시 캐릭터 및 관련 데이터가 삭제됩니다.

## 🌱 To be noted
> PR을 검토할 때 확인해야 할 사항이 있나요?
- 캐릭터 엔티티 필드에 cascade 설정이 추가되었습니다.
- 탈퇴 시, refresh 토큰 저장 부분도 삭제됩니다.

## 💫 issue number
> 이슈 번호를 작성해주새요
- #53 

## ☑️ Checklist
> PR 요청 시 체크해주세요.
- [x] label
- [x] issue number
- [x] conflict resolve

## 💡 Comment
> 전달하고 싶은 내용이 있나요?
- 유저와 캐릭터 삭제 로직이 모두 있는 이유는, 두 관계가 단방향이라 cascade 설정을 유저 필드에 추가하지 못해서 이렇게 구현하였습니다. 
- 이 부분때문에 양방향을 추가 설정하는 방법보다는 나을 것 같다는 판단이 들었습니다!
- 